### PR TITLE
Feat/achievements performance update

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Achievement system for the Hermes Dashboard: collectible, tiered badges generate
 
 The screenshots use temporary demo tier data to show the full visual range. The plugin itself reads real local Hermes session history by default.
 
+> **Update notice (2026-04-29):** If you installed this plugin before today, update to the latest version. The achievements scan path was refactored for much faster warm loads (snapshot cache + incremental checkpoint scan).
+
 ## What it does
 
 Hermes Achievements scans local Hermes sessions and unlocks badges based on real agent behavior:
@@ -83,6 +85,11 @@ curl http://127.0.0.1:9119/api/dashboard/plugins/rescan
 
 If the update changes backend routes or `plugin_api.py`, restart `hermes dashboard` after pulling.
 
+As of 2026-04-29, updating is strongly recommended because scan performance changed significantly:
+- removed duplicate `/overview` scan path
+- added cached `/achievements` snapshot
+- added incremental checkpoint reuse for unchanged sessions
+
 Achievement unlock state is stored locally in `state.json` and is not overwritten by git updates. New achievements are evaluated from your existing Hermes session history. Achievement IDs are stable and should not be renamed casually because they are the unlock-state keys.
 
 Releases are tagged in git, for example:
@@ -114,8 +121,8 @@ Routes are mounted under:
 Endpoints:
 
 ```text
-GET  /overview
 GET  /achievements
+GET  /scan-status
 GET  /recent-unlocks
 GET  /sessions/{session_id}/badges
 POST /rescan

--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -262,20 +262,5 @@
     );
   }
 
-  function SummarySlot({ compact }) {
-    const [overview, setOverview] = hooks.useState(null);
-    hooks.useEffect(function () { api("/overview").then(setOverview).catch(function () {}); }, []);
-    if (!overview) return null;
-    return React.createElement(C.Card, { className: "ha-slot" },
-      React.createElement(C.CardContent, { className: "ha-slot-content" },
-        React.createElement("span", { className: "ha-slot-star" }, "◇"),
-        React.createElement("span", null, "Hermes Achievements: ", React.createElement("strong", null, overview.unlocked_count, " / ", overview.total_count), " unlocked"),
-        !compact && overview.latest && overview.latest[0] && React.createElement("span", { className: "ha-slot-muted" }, "Latest: " + overview.latest[0].name)
-      )
-    );
-  }
-
   window.__HERMES_PLUGINS__.register("hermes-achievements", AchievementsPage);
-  window.__HERMES_PLUGINS__.registerSlot("hermes-achievements", "sessions:top", function () { return React.createElement(SummarySlot, { compact: false }); });
-  window.__HERMES_PLUGINS__.registerSlot("hermes-achievements", "analytics:top", function () { return React.createElement(SummarySlot, { compact: true }); });
 })();

--- a/dashboard/manifest.json
+++ b/dashboard/manifest.json
@@ -5,7 +5,6 @@
   "icon": "Star",
   "version": "0.2.2",
   "tab": { "path": "/achievements", "position": "after:analytics" },
-  "slots": ["sessions:top", "analytics:top"],
   "entry": "dist/index.js",
   "css": "dist/style.css",
   "api": "plugin_api.py"

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import math
 import re
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set
@@ -21,6 +22,19 @@ except Exception:  # Allows local unit tests without dashboard dependencies.
             return lambda fn: fn
 
 router = APIRouter()
+
+SNAPSHOT_TTL_SECONDS = 120
+_SCAN_LOCK = threading.Lock()
+_SNAPSHOT_CACHE: Optional[Dict[str, Any]] = None
+_SNAPSHOT_CACHE_AT = 0
+_SCAN_STATUS: Dict[str, Any] = {
+    "state": "idle",
+    "started_at": None,
+    "finished_at": None,
+    "last_error": None,
+    "last_duration_ms": None,
+    "run_count": 0,
+}
 
 ERROR_RE = re.compile(r"\b(error|failed|failure|traceback|exception|permission denied|not found|eaddrinuse|already in use|timed out|blocked)\b", re.I)
 PORT_RE = re.compile(r"\b(port\s+)?(3000|5173|8000|8080|9119)\b.*\b(in use|already|taken|eaddrinuse)\b|\beaddrinuse\b", re.I)
@@ -124,6 +138,14 @@ def state_path() -> Path:
     return Path.home() / ".hermes" / "plugins" / "hermes-achievements" / "state.json"
 
 
+def snapshot_path() -> Path:
+    return Path.home() / ".hermes" / "plugins" / "hermes-achievements" / "scan_snapshot.json"
+
+
+def checkpoint_path() -> Path:
+    return Path.home() / ".hermes" / "plugins" / "hermes-achievements" / "scan_checkpoint.json"
+
+
 def load_state() -> Dict[str, Any]:
     path = state_path()
     if not path.exists():
@@ -138,6 +160,99 @@ def save_state(state: Dict[str, Any]) -> None:
     path = state_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(state, indent=2, sort_keys=True))
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_json_safe(v) for v in value)
+    return value
+
+
+def load_snapshot() -> Optional[Dict[str, Any]]:
+    path = snapshot_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        return None
+    return None
+
+
+def save_snapshot(data: Dict[str, Any]) -> None:
+    path = snapshot_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
+
+
+def load_checkpoint() -> Dict[str, Any]:
+    path = checkpoint_path()
+    if not path.exists():
+        return {"schema_version": 1, "generated_at": 0, "sessions": {}}
+    try:
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            data.setdefault("schema_version", 1)
+            data.setdefault("generated_at", 0)
+            data.setdefault("sessions", {})
+            if isinstance(data.get("sessions"), dict):
+                return data
+    except Exception:
+        pass
+    return {"schema_version": 1, "generated_at": 0, "sessions": {}}
+
+
+def save_checkpoint(data: Dict[str, Any]) -> None:
+    path = checkpoint_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(_json_safe(data), indent=2, sort_keys=True))
+
+
+def session_fingerprint(meta: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "last_active": meta.get("last_active"),
+        "started_at": meta.get("started_at"),
+        "model": meta.get("model"),
+        "title": meta.get("title") or meta.get("preview") or "Untitled",
+    }
+
+
+def _cache_is_fresh(now: int) -> bool:
+    return _SNAPSHOT_CACHE is not None and (now - _SNAPSHOT_CACHE_AT) <= SNAPSHOT_TTL_SECONDS
+
+
+def _is_snapshot_stale(snapshot: Optional[Dict[str, Any]], now: Optional[int] = None) -> bool:
+    if not isinstance(snapshot, dict):
+        return True
+    ts = int(snapshot.get("generated_at") or 0)
+    current = int(now or time.time())
+    if ts <= 0:
+        return True
+    return (current - ts) > SNAPSHOT_TTL_SECONDS
+
+
+def _scan_status_payload(now: Optional[int] = None) -> Dict[str, Any]:
+    current = int(now or time.time())
+    snap = _SNAPSHOT_CACHE if isinstance(_SNAPSHOT_CACHE, dict) else None
+    generated_at = int((snap or {}).get("generated_at") or 0) if snap else 0
+    return {
+        "state": _SCAN_STATUS.get("state", "idle"),
+        "started_at": _SCAN_STATUS.get("started_at"),
+        "finished_at": _SCAN_STATUS.get("finished_at"),
+        "last_error": _SCAN_STATUS.get("last_error"),
+        "last_duration_ms": _SCAN_STATUS.get("last_duration_ms"),
+        "run_count": _SCAN_STATUS.get("run_count", 0),
+        "ttl_seconds": SNAPSHOT_TTL_SECONDS,
+        "snapshot_generated_at": generated_at or None,
+        "snapshot_age_seconds": (current - generated_at) if generated_at else None,
+        "snapshot_stale": _is_snapshot_stale(snap, current),
+    }
 
 
 def _tool_name_from_call(call: Any) -> Optional[str]:
@@ -438,27 +553,72 @@ def scan_sessions(limit: int = 200) -> Dict[str, Any]:
     try:
         from hermes_state import SessionDB
     except Exception as exc:
-        return {"sessions": [], "aggregate": {}, "error": f"Could not import SessionDB: {exc}"}
+        return {"sessions": [], "aggregate": {}, "error": f"Could not import SessionDB: {exc}", "scan_meta": {"mode": "failed", "sessions_total": 0, "sessions_rescanned": 0, "sessions_reused": 0}}
+
+    checkpoint = load_checkpoint()
+    previous_sessions = checkpoint.get("sessions") if isinstance(checkpoint.get("sessions"), dict) else {}
+    reused = 0
+    rescanned = 0
 
     db = SessionDB()
     try:
         sessions_meta = db.list_sessions_rich(limit=limit, include_children=True, project_compression_tips=False)
         sessions = []
+        checkpoint_sessions: Dict[str, Any] = {}
         for meta in sessions_meta:
             sid = meta.get("id")
-            messages = db.get_messages(sid) if sid else []
-            stats = analyze_messages(sid, meta.get("title") or meta.get("preview") or "Untitled", messages)
+            if not sid:
+                continue
+            fp = session_fingerprint(meta)
+            cached = previous_sessions.get(sid) if isinstance(previous_sessions, dict) else None
+            cached_stats = cached.get("stats") if isinstance(cached, dict) else None
+            cached_fp = cached.get("fingerprint") if isinstance(cached, dict) else None
+
+            if isinstance(cached_stats, dict) and cached_fp == fp:
+                stats = dict(cached_stats)
+                reused += 1
+            else:
+                messages = db.get_messages(sid)
+                stats = analyze_messages(sid, meta.get("title") or meta.get("preview") or "Untitled", messages)
+                rescanned += 1
+
+            stats["session_id"] = sid
+            stats["title"] = meta.get("title") or meta.get("preview") or stats.get("title") or "Untitled"
             stats["started_at"] = meta.get("started_at")
             stats["last_active"] = meta.get("last_active")
             stats["source"] = meta.get("source")
             if meta.get("model"):
-                stats["model_names"].add(str(meta.get("model")))
+                stats.setdefault("model_names", set())
+                if isinstance(stats["model_names"], set):
+                    stats["model_names"].add(str(meta.get("model")))
+                elif isinstance(stats["model_names"], list):
+                    if str(meta.get("model")) not in stats["model_names"]:
+                        stats["model_names"].append(str(meta.get("model")))
+                else:
+                    stats["model_names"] = {str(meta.get("model"))}
+
             sessions.append(stats)
+            checkpoint_sessions[sid] = {"fingerprint": fp, "stats": _json_safe(stats)}
+
+        save_checkpoint({
+            "schema_version": 1,
+            "generated_at": int(time.time()),
+            "sessions": checkpoint_sessions,
+        })
     finally:
         close = getattr(db, "close", None)
         if close:
             close()
-    return {"sessions": sessions, "aggregate": aggregate_stats(sessions)}
+    return {
+        "sessions": sessions,
+        "aggregate": aggregate_stats(sessions),
+        "scan_meta": {
+            "mode": "incremental" if reused > 0 else "full",
+            "sessions_total": len(sessions),
+            "sessions_rescanned": rescanned,
+            "sessions_reused": reused,
+        },
+    }
 
 
 def aggregate_stats(sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -574,7 +734,7 @@ def evidence_for(definition: Dict[str, Any], sessions: List[Dict[str, Any]]) -> 
     return None
 
 
-def evaluate_all() -> Dict[str, Any]:
+def compute_all() -> Dict[str, Any]:
     scan = scan_sessions()
     aggregate = scan.get("aggregate", {})
     state = load_state()
@@ -595,22 +755,82 @@ def evaluate_all() -> Dict[str, Any]:
     unlocked = [a for a in evaluated if a["unlocked"]]
     discovered = [a for a in evaluated if a.get("state") == "discovered"]
     secret = [a for a in evaluated if a.get("state") == "secret"]
-    return {"achievements": evaluated, "sessions": scan.get("sessions", []), "aggregate": aggregate, "error": scan.get("error"), "unlocked_count": len(unlocked), "discovered_count": len(discovered), "secret_count": len(secret), "total_count": len(evaluated)}
+    return {
+        "achievements": evaluated,
+        "sessions": scan.get("sessions", []),
+        "aggregate": aggregate,
+        "scan_meta": scan.get("scan_meta", {}),
+        "error": scan.get("error"),
+        "unlocked_count": len(unlocked),
+        "discovered_count": len(discovered),
+        "secret_count": len(secret),
+        "total_count": len(evaluated),
+        "generated_at": now,
+    }
+
+
+def evaluate_all(force: bool = False) -> Dict[str, Any]:
+    global _SNAPSHOT_CACHE, _SNAPSHOT_CACHE_AT
+    now = int(time.time())
+
+    if not force and _cache_is_fresh(now):
+        return _SNAPSHOT_CACHE or {}
+
+    if not force and _SNAPSHOT_CACHE is None:
+        persisted = load_snapshot()
+        if isinstance(persisted, dict):
+            generated_at = int(persisted.get("generated_at") or 0)
+            _SNAPSHOT_CACHE = persisted
+            _SNAPSHOT_CACHE_AT = generated_at or now
+            if (now - _SNAPSHOT_CACHE_AT) <= SNAPSHOT_TTL_SECONDS:
+                return _SNAPSHOT_CACHE
+
+    with _SCAN_LOCK:
+        now = int(time.time())
+        if not force and _cache_is_fresh(now):
+            return _SNAPSHOT_CACHE or {}
+
+        started = int(time.time())
+        _SCAN_STATUS["state"] = "running"
+        _SCAN_STATUS["started_at"] = started
+        _SCAN_STATUS["last_error"] = None
+        try:
+            computed = compute_all()
+            _SNAPSHOT_CACHE = _json_safe(computed)
+            _SNAPSHOT_CACHE_AT = int(_SNAPSHOT_CACHE.get("generated_at") or int(time.time()))
+            save_snapshot(_SNAPSHOT_CACHE)
+            _SCAN_STATUS["state"] = "idle"
+            _SCAN_STATUS["finished_at"] = int(time.time())
+            _SCAN_STATUS["last_duration_ms"] = int((_SCAN_STATUS["finished_at"] - started) * 1000)
+            _SCAN_STATUS["run_count"] = int(_SCAN_STATUS.get("run_count", 0)) + 1
+            return _SNAPSHOT_CACHE
+        except Exception as exc:
+            _SCAN_STATUS["state"] = "failed"
+            _SCAN_STATUS["finished_at"] = int(time.time())
+            _SCAN_STATUS["last_duration_ms"] = int((_SCAN_STATUS["finished_at"] - started) * 1000)
+            _SCAN_STATUS["last_error"] = str(exc)
+            _SCAN_STATUS["run_count"] = int(_SCAN_STATUS.get("run_count", 0)) + 1
+            if _SNAPSHOT_CACHE is not None:
+                return _SNAPSHOT_CACHE
+            raise
 
 
 @router.get("/achievements")
 async def achievements():
     data = evaluate_all()
-    return {k: data[k] for k in ["achievements", "unlocked_count", "discovered_count", "secret_count", "total_count", "error"] if k in data}
+    payload = {k: data[k] for k in ["achievements", "unlocked_count", "discovered_count", "secret_count", "total_count", "error", "generated_at"] if k in data}
+    payload["is_stale"] = _is_snapshot_stale(data)
+    payload["scan_meta"] = {
+        **(data.get("scan_meta") or {}),
+        "status": _scan_status_payload(),
+    }
+    return payload
 
 
-@router.get("/overview")
-async def overview():
-    data = evaluate_all()
-    unlocked = [a for a in data["achievements"] if a["unlocked"]]
-    latest = sorted(unlocked, key=lambda a: a.get("unlocked_at") or 0, reverse=True)[:5]
-    categories = sorted({a["category"] for a in data["achievements"]})
-    return {"unlocked_count": data["unlocked_count"], "discovered_count": data["discovered_count"], "secret_count": data["secret_count"], "total_count": data["total_count"], "aggregate": data["aggregate"], "latest": latest, "categories": categories, "error": data.get("error")}
+@router.get("/scan-status")
+async def scan_status():
+    evaluate_all()
+    return _scan_status_payload()
 
 
 @router.get("/recent-unlocks")
@@ -636,10 +856,26 @@ async def session_badges(session_id: str):
 
 @router.post("/rescan")
 async def rescan():
-    return {"ok": True, **evaluate_all()}
+    return {"ok": True, **evaluate_all(force=True)}
 
 
 @router.post("/reset-state")
 async def reset_state():
+    global _SNAPSHOT_CACHE, _SNAPSHOT_CACHE_AT
     save_state({"unlocks": {}})
+    _SNAPSHOT_CACHE = None
+    _SNAPSHOT_CACHE_AT = 0
+    _SCAN_STATUS["state"] = "idle"
+    _SCAN_STATUS["started_at"] = None
+    _SCAN_STATUS["finished_at"] = None
+    _SCAN_STATUS["last_error"] = None
+    _SCAN_STATUS["last_duration_ms"] = None
+    try:
+        snapshot_path().unlink(missing_ok=True)
+    except Exception:
+        pass
+    try:
+        checkpoint_path().unlink(missing_ok=True)
+    except Exception:
+        pass
     return {"ok": True}

--- a/dashboard/plugin_api.py
+++ b/dashboard/plugin_api.py
@@ -829,7 +829,6 @@ async def achievements():
 
 @router.get("/scan-status")
 async def scan_status():
-    evaluate_all()
     return _scan_status_payload()
 
 

--- a/docs/achievements-performance-implementation-plan.md
+++ b/docs/achievements-performance-implementation-plan.md
@@ -1,0 +1,157 @@
+# Hermes Achievements Performance Implementation Plan
+
+Status: Ready for execution after hackathon review window
+Constraint: Plugin remains frozen until judging is complete
+Decision: `/overview` and top-banner slots are out of scope and will be removed.
+
+---
+
+## Phase 0 — Baseline & Safety (no behavior change)
+
+### Task 0.1: Add perf benchmark script (local)
+Objective: Repro baseline before/after.
+
+Acceptance:
+- Can print endpoint timings for `/achievements` (3 runs each, cold + warm).
+
+### Task 0.2: Define acceptance thresholds
+Objective: Lock success criteria now.
+
+Acceptance:
+- Documented SLOs:
+  - `/achievements` p95 < 1s (cached)
+  - max active scan jobs = 1
+
+---
+
+## Phase 1 — Remove unused overview/slot surface (highest certainty)
+
+### Task 1.1: Remove `/overview` backend route
+Objective: Eliminate duplicate heavy endpoint path.
+
+Acceptance:
+- `plugin_api.py` no longer exposes `/overview`.
+
+### Task 1.2: Remove slot registration and SummarySlot frontend code
+Objective: Remove cross-tab banner fetch behavior.
+
+Acceptance:
+- No `registerSlot(..."sessions:top"...)` or `registerSlot(..."analytics:top"...)`.
+- No frontend call to `api("/overview")`.
+
+### Task 1.3: Update plugin manifest
+Objective: Reflect final UI scope.
+
+Acceptance:
+- `manifest.json` removes `slots` declarations.
+- Tab registration remains intact.
+
+---
+
+## Phase 2 — Shared snapshot persistence + single-flight for `/achievements`
+
+### Task 2.1: Introduce snapshot store abstraction + on-disk persistence
+Objective: Single source of truth for Achievements data that survives process restarts.
+
+Acceptance:
+- One structure contains dataset consumed by `/achievements`.
+- Repeated requests do not recompute when cache is fresh.
+- Snapshot persisted at `~/.hermes/plugins/hermes-achievements/scan_snapshot.json`.
+
+### Task 2.2: Single-flight scan coordinator
+Objective: Prevent concurrent recomputes.
+
+Acceptance:
+- Simultaneous requests result in one compute run.
+
+### Task 2.3: Refactor `/achievements` to read snapshot
+Objective: Remove direct repeated compute from request path.
+
+Acceptance:
+- `/achievements` does not run independent full recompute per request when cache is valid.
+
+---
+
+## Phase 3 — Stale-While-Revalidate
+
+### Task 3.1: TTL state (`FRESH`/`STALE`)
+Objective: Serve immediately when stale, refresh in background.
+
+Acceptance:
+- Cached response returned quickly even when expired.
+- Refresh is asynchronous.
+
+### Task 3.2: Add `scan-status` endpoint (optional)
+Objective: Let UI/ops inspect scan state.
+
+Acceptance:
+- Returns state, last success time, last duration, last error.
+
+### Task 3.3: Add metadata fields to `/achievements`
+Objective: Improve transparency.
+
+Acceptance:
+- Response includes `generated_at`, `is_stale`, maybe `scan_id`.
+
+---
+
+## Phase 4 — Incremental Scanning (optional but recommended)
+
+### Task 4.1: Add per-session checkpoint file
+Objective: Track session-level changes, not just global scan time.
+
+Acceptance:
+- Checkpoint persisted at `~/.hermes/plugins/hermes-achievements/scan_checkpoint.json`.
+- For each session: `session_id`, fingerprint (`updated_at`/message_count/hash), and cached contribution.
+
+### Task 4.2: Incremental aggregation
+Objective: Recompute only changed/new sessions and reuse unchanged contributions.
+
+Acceptance:
+- Typical refresh time drops materially below full scan.
+- Aggregate rebuild uses: subtract old contribution + add new contribution for changed sessions.
+
+### Task 4.3: Full rebuild fallback
+Objective: Preserve correctness.
+
+Acceptance:
+- Manual full rescan always possible.
+- Schema/version changes invalidate checkpoint and force full rebuild.
+
+---
+
+## Test Plan
+
+1. Unit tests
+- Snapshot lifecycle transitions
+- Dedupe logic under parallel requests
+- `/achievements` response compatibility
+
+2. Integration tests
+- Opening Achievements repeatedly causes <=1 heavy scan while in-flight
+- `/achievements` warm-cache load is fast
+- manual rescan updates snapshot and timestamps
+
+3. Manual benchmarks
+- Compare pre/post `/achievements` timings with same history dataset
+
+---
+
+## Rollout Plan
+
+1. Release internal branch with Phase 1 (remove overview/slots).
+2. Validate no UI regression in Achievements tab.
+3. Add Phase 2 snapshot/dedupe.
+4. Add Phase 3 stale-while-revalidate + status metadata.
+5. Optional: incremental scanner.
+
+Rollback: keep old compute path behind temporary feature flag for one release window.
+
+---
+
+## Definition of Done
+
+- Achievements tab remains fully functional (counts, latest, tiers, cards, filters).
+- No `/overview` endpoint or slot calls remain.
+- Repeated Achievements loads feel immediate after warm cache.
+- Metrics/unlocks remain unchanged versus baseline.

--- a/docs/achievements-performance-implementation-spec.md
+++ b/docs/achievements-performance-implementation-spec.md
@@ -1,0 +1,219 @@
+# Hermes Achievements Implementation Spec (Detailed)
+
+This document is implementation-facing detail to execute the performance refactor later.
+
+Decision scope: keep only Achievements tab flow; remove `/overview` + top-banner slot integration.
+
+---
+
+## A) Current Behavior Summary
+
+- `evaluate_all()` performs:
+  - full `scan_sessions()`
+  - `SessionDB.list_sessions_rich(...)`
+  - `db.get_messages(session_id)` for each session
+  - text/tool regex analysis + aggregation + evaluation
+- `/overview` and `/achievements` both currently call `evaluate_all()` directly.
+- slot calls (`sessions:top`, `analytics:top`) currently invoke `/overview`.
+
+Consequence: repeated full recomputes and contention.
+
+---
+
+## B) De-scope/Removal Changes
+
+1. Remove backend route:
+- `GET /overview`
+
+2. Remove frontend slot usage:
+- `SummarySlot` component
+- `registerSlot("sessions:top")`
+- `registerSlot("analytics:top")`
+
+3. Remove manifest slot declarations:
+- `"slots": ["sessions:top", "analytics:top"]`
+
+4. Keep:
+- tab route/page for Achievements
+- `/achievements` endpoint and full tab rendering
+
+---
+
+## C) Target Internal Interfaces
+
+### 1) `SnapshotStore`
+Responsibilities:
+- hold latest computed snapshot in memory
+- persist/load snapshot from disk
+- expose age and staleness checks
+
+Storage path:
+- `~/.hermes/plugins/hermes-achievements/scan_snapshot.json`
+
+Methods (conceptual):
+- `get()` -> snapshot | null
+- `set(snapshot)`
+- `is_stale(ttl_seconds)`
+
+### 2) `ScanCoordinator`
+Responsibilities:
+- single-flight guard for compute jobs
+- track scan status
+
+Methods:
+- `run_if_needed(force: bool = false)`
+- `get_status()`
+
+State fields:
+- `state`: `idle|running|failed`
+- `started_at`, `finished_at`
+- `last_error`
+- `run_count`
+
+### 3) `build_snapshot()`
+Responsibilities:
+- execute current compute logic once
+- on first run, perform full scan and materialize per-session contributions
+- on subsequent runs, process only changed/new sessions via checkpoint fingerprints
+- produce shape consumed by `/achievements`
+
+Output:
+- `achievements`
+- count fields
+- optional `scan_meta`
+
+---
+
+## D) Endpoint Behavior Matrix (No `/overview`)
+
+| Endpoint | Cache fresh | Cache stale | No cache | Force rescan |
+|---|---|---|---|---|
+| `/achievements` | return cached | return stale + trigger bg refresh | blocking bootstrap scan | n/a |
+| `/rescan` | trigger refresh | trigger refresh | trigger refresh | yes |
+| `/scan-status` | status only | status only | status only | status only |
+
+Notes:
+- At most one scan run active.
+- Other callers either await same run or receive stale snapshot according to policy.
+
+---
+
+## E) Data Shape (Proposed)
+
+```json
+{
+  "generated_at": 0,
+  "is_stale": false,
+  "scan_meta": {
+    "duration_ms": 0,
+    "sessions_scanned": 0,
+    "messages_scanned": 0,
+    "mode": "full",
+    "error": null
+  },
+  "achievements": [],
+  "unlocked_count": 0,
+  "discovered_count": 0,
+  "secret_count": 0,
+  "total_count": 0,
+  "error": null
+}
+```
+
+Compatibility guidance:
+- Keep existing `/achievements` keys.
+- Add metadata keys without breaking old callers.
+
+Checkpoint file (new):
+- `~/.hermes/plugins/hermes-achievements/scan_checkpoint.json`
+
+Suggested checkpoint shape:
+```json
+{
+  "schema_version": 1,
+  "generated_at": 0,
+  "sessions": {
+    "<session_id>": {
+      "fingerprint": {
+        "updated_at": 0,
+        "message_count": 0,
+        "hash": "optional"
+      },
+      "contribution": {
+        "metrics": {}
+      }
+    }
+  }
+}
+```
+
+Notes:
+- fingerprint mismatch => recompute that session contribution only.
+- unchanged fingerprint => reuse stored contribution.
+
+---
+
+## F) Concurrency Contract
+
+- Any request path that needs fresh data must pass through single-flight coordinator.
+- If a scan is running:
+  - do not start second scan
+  - either await in-flight run (bounded) or serve stale snapshot immediately
+- lock scope must include scan start/finish state transitions.
+
+---
+
+## G) Error Handling Contract
+
+- If refresh fails and prior snapshot exists:
+  - return prior snapshot with `is_stale=true` and error metadata
+- If refresh fails and no prior snapshot:
+  - return explicit error response (current behavior equivalent)
+- `scan-status` should always return last known state/error.
+
+---
+
+## H) Frontend Integration Contract
+
+- Achievements page:
+  - one fetch on mount to `/achievements`
+  - optional background refresh indicator if stale
+- no top-banner slot integration
+- avoid duplicate in-flight calls during fast navigation by cancellation/debounce.
+
+---
+
+## I) Validation Checklist
+
+- [ ] `/overview` route removed
+- [ ] manifest has no `sessions:top`/`analytics:top` slots
+- [ ] frontend has no `api("/overview")` calls
+- [ ] repeated Achievements navigation does not create multiple heavy scans
+- [ ] average warm load times meet SLOs
+- [ ] unlock totals match pre-refactor baseline for same history
+- [ ] no schema regression in `/achievements` response
+
+---
+
+## J) Suggested File Placement for Future Work
+
+- backend changes: `dashboard/plugin_api.py`
+- optional extraction:
+  - `dashboard/perf_snapshot.py`
+  - `dashboard/perf_scan_coordinator.py`
+- frontend request hygiene: `dashboard/dist/index.js` (or source if available)
+- plugin metadata: `dashboard/manifest.json`
+- persisted runtime files:
+  - `~/.hermes/plugins/hermes-achievements/state.json` (existing unlock state)
+  - `~/.hermes/plugins/hermes-achievements/scan_snapshot.json` (new)
+  - `~/.hermes/plugins/hermes-achievements/scan_checkpoint.json` (new)
+
+---
+
+## K) Post-Implementation Reporting Template
+
+Record:
+- dataset size (sessions/messages/tool calls)
+- pre/post `/achievements` timings (cold/warm)
+- whether single-flight dedupe triggered under repeated tab open
+- any behavioral diffs in unlock counts

--- a/docs/achievements-performance-spec.md
+++ b/docs/achievements-performance-spec.md
@@ -1,0 +1,174 @@
+# Hermes Achievements Performance Spec (Post-Hackathon)
+
+Status: Draft (no code changes yet)
+Owner: hermes-achievements plugin
+Scope: `dashboard/plugin_api.py` + `dashboard/dist/index.js` request behavior
+Decision: **Drop `/overview` and top-banner slots**; keep only Achievements tab data path.
+
+---
+
+## 1) Problem Statement
+
+Current plugin endpoints `/achievements` and `/overview` both execute a full history recomputation (`evaluate_all()`), which performs a full SessionDB scan each request.
+
+Observed on this machine/repo:
+- ~83 sessions
+- ~7,125 messages
+- ~3,623 tool calls
+- `evaluate_all()` ~13–16s per call
+- `/achievements` ~13–15s per call
+- `/overview` ~12–15s per call
+- Overlap between endpoints increases perceived wait.
+
+Given current product direction, `/overview` and cross-tab top-banner slots are not needed.
+
+---
+
+## 2) Goals
+
+- Keep achievement correctness unchanged.
+- Keep all Achievements-tab UX/data (unlocked/discovered/secrets/highest/latest/cards).
+- Remove unused summary path (`/overview`) and slot wiring.
+- Make Achievements tab faster by avoiding duplicate endpoint pathways.
+- Ensure at most one heavy scan can run at a time.
+
+Non-goals (phase 1):
+- Rewriting achievement rules.
+- Changing badge semantics/states.
+
+---
+
+## 3) Endpoint Semantics (Target)
+
+### `GET /api/plugins/hermes-achievements/achievements`
+Single source endpoint for Achievements UI.
+Returns full payload used by the tab:
+- `achievements`
+- `unlocked_count`
+- `discovered_count`
+- `secret_count`
+- `total_count`
+- `error`
+
+### `POST /api/plugins/hermes-achievements/rescan` (optional)
+Manual refresh trigger.
+Prefer async trigger + immediate status response.
+
+### `GET /api/plugins/hermes-achievements/scan-status` (optional new)
+Reports scan state for UX/ops.
+
+### Removed
+- `GET /api/plugins/hermes-achievements/overview`
+
+---
+
+## 4) UI Scope (Target)
+
+Keep:
+- Achievements page/tab (`/achievements` in plugin tab manifest)
+- All existing Achievements tab stats/cards/filters
+
+Remove:
+- Top-banner summary slot components using `sessions:top` and `analytics:top`
+- Any frontend call path to `/overview`
+
+---
+
+## 5) Runtime State Machine (for `/achievements`)
+
+- `FRESH`: cached snapshot age <= TTL
+- `STALE`: snapshot exists but expired
+- `SCANNING`: background recompute running
+- `FAILED`: last recompute failed, last good snapshot still served
+
+Rules:
+1. FRESH -> serve immediately.
+2. STALE + not scanning -> serve stale snapshot immediately and launch background refresh.
+3. SCANNING -> do not start another scan; join single-flight in-flight job.
+4. No snapshot yet -> allow one blocking bootstrap scan.
+
+---
+
+## 6) Caching & Invalidation
+
+### Phase 1
+- In-memory cache + persisted snapshot file.
+- TTL: 60–180 seconds (configurable).
+- Single-flight dedupe for scan requests.
+- Persist plugin data under:
+  - `~/.hermes/plugins/hermes-achievements/scan_snapshot.json`
+
+### Phase 2
+- Incremental scan checkpoints with per-session fingerprints.
+- Persist checkpoint data under:
+  - `~/.hermes/plugins/hermes-achievements/scan_checkpoint.json`
+- Checkpoint stores, per session:
+  - `session_id`
+  - fingerprint (`updated_at`, message_count, or hash)
+  - cached per-session contribution used for aggregate recomposition
+- Scan policy:
+  - First run: full scan and materialize snapshot + checkpoint.
+  - Next runs: process only new/changed sessions, reuse unchanged contributions.
+- Full rebuild only on:
+  - schema/version change
+  - checkpoint corruption
+  - explicit full rescan
+
+---
+
+## 7) Frontend Contract
+
+- Achievements tab requests `/achievements` once on mount.
+- No slot-based summary fetches.
+- If response says `is_stale=true`, UI may display “Updating in background”.
+- Avoid duplicate mount-triggered calls and cancel stale requests on navigation.
+
+---
+
+## 8) SLO Targets
+
+- `/achievements` p95 < 1s (cached)
+- Max concurrent heavy scans: 1
+- Background refresh should not block UI
+
+---
+
+## 9) Observability Requirements
+
+Track:
+- scan count
+- scan duration avg/p95
+- dedupe hit count (joined in-flight scans)
+- stale-served count
+- failures + last error
+
+Expose minimal diagnostics in `/scan-status`.
+
+---
+
+## 10) Backward Compatibility
+
+- Keep `/achievements` response shape backward-compatible.
+- Removing `/overview` is acceptable because slot UI is intentionally removed.
+- If temporary compatibility is needed, `/overview` can return static deprecation response for one release.
+
+---
+
+## 11) Risks
+
+- Stale data confusion -> mitigate with `generated_at` and explicit refresh status.
+- Cache invalidation bugs -> start with conservative TTL + manual rescan.
+- Concurrency bugs -> protect scan section with lock/single-flight guard.
+- Session mutation edge cases -> use per-session fingerprint invalidation (not global timestamp only).
+
+---
+
+## 12) Persistence Files (Explicit)
+
+Plugin state directory:
+- `~/.hermes/plugins/hermes-achievements/`
+
+Files:
+- `state.json` (existing): unlock tracking
+- `scan_snapshot.json` (new): latest materialized achievements payload
+- `scan_checkpoint.json` (new): per-session fingerprints + contributions for incremental refresh


### PR DESCRIPTION
## Summary
This PR improves Hermes Achievements tab performance by removing duplicate trigger paths and adding cached/incremental scan execution.

## What changed
- Removed unused `/overview` route and top-banner slot integration
  - removed slot registrations from dashboard JS
  - removed `slots` from plugin manifest
- Added snapshot caching for `/achievements`
  - in-memory cache with TTL
  - persisted snapshot at `~/.hermes/plugins/hermes-achievements/scan_snapshot.json`
- Added single-flight scan guard
  - concurrent requests reuse one scan run instead of duplicating work
- Added scan observability
  - `GET /scan-status` endpoint
  - `/achievements` now returns `generated_at`, `is_stale`, and `scan_meta`
- Added incremental checkpoint scanning
  - checkpoint at `~/.hermes/plugins/hermes-achievements/scan_checkpoint.json`
  - reuse unchanged session stats, rescan only changed/new sessions
  - reports `mode`, `sessions_rescanned`, `sessions_reused`, `sessions_total`
- Made `/scan-status` read-only (non-triggering)

## Why
Previously the plugin could repeatedly perform full history scans during navigation. This PR reduces repeated heavy work and makes subsequent loads effectively instant in normal usage.

## Validation
- Python syntax check passes (`py_compile`)
- Endpoint smoke checks run for:
  - `GET /achievements`
  - `GET /scan-status`
  - `POST /rescan`
  - `POST /reset-state`
- Verified warm behavior with live dashboard endpoint:
  - cached/incremental responses are fast
  - `/scan-status` no longer triggers scans

## Notes
- First load after reset/cold start can still be slower (expected) because snapshot/checkpoint are rebuilt.
