### PR TITLE
fix: inject X-Hermes-Session-Token header in API calls

### DIFF
--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -14,9 +14,19 @@
     return tier ? "ha-tier-" + tier.toLowerCase() : "ha-tier-pending";
   };
 
+  // Capture the session token synchronously before any async work.
+  // The token is injected as a blocking <script> in index.html, so it is
+  // always available by the time this module executes.
+  const _sessionToken = window.__HERMES_SESSION_TOKEN__;
+
   async function api(path, options) {
     const url = "/api/plugins/hermes-achievements" + path;
-    const res = await fetch(url, options || {});
+    const _options = options || {};
+    const _headers = new Headers(_options.headers);
+    if (_sessionToken && !_headers.has("X-Hermes-Session-Token")) {
+      _headers.set("X-Hermes-Session-Token", _sessionToken);
+    }
+    const res = await fetch(url, Object.assign({}, _options, { headers: _headers }));
     if (!res.ok) {
       const text = await res.text().catch(function () { return res.statusText; });
       throw new Error(res.status + ": " + text);


### PR DESCRIPTION
The hermes-agent dashboard requires an X-Hermes-Session-Token header on all /api/plugins/* routes. The bundled JS was making fetch() calls without this header, causing 401 Unauthorized errors on the Achievements page.

Fix: capture the session token synchronously at module load time (before any async work) and inject it as a header on every API call. This avoids race conditions where the token is read after the first fetch has already failed. The token is injected as a blocking <script> in index.html, so it is always available by the time this module executes.