### PR TITLE
fix(dashboard): honor base path for reverse-proxy dashboards (HA add-on 404)

### DIFF
--- a/dashboard/dist/index.js
+++ b/dashboard/dist/index.js
@@ -20,7 +20,8 @@
   const _sessionToken = window.__HERMES_SESSION_TOKEN__;
 
   async function api(path, options) {
-    const url = "/api/plugins/hermes-achievements" + path;
+    const basePath = (window.__HERMES_BASE_PATH__ || "").replace(/\/$/, "");
+    const url = basePath + "/api/plugins/hermes-achievements" + path;
     const _options = options || {};
     const _headers = new Headers(_options.headers);
     if (_sessionToken && !_headers.has("X-Hermes-Session-Token")) {


### PR DESCRIPTION
## Summary

The bundled API URL builder in `dashboard/dist/index.js` hardcodes `/api/plugins/hermes-achievements` as an absolute root path. When the Hermes dashboard is served behind a reverse-proxy prefix — most commonly the Home Assistant add-on at `/dashboard/...` — that request bypasses the dashboard proxy route, hits the host at `/api/...` directly, and returns **404**. The Achievements page renders as:

```
Error: 404: 404: Not Found
```

The Hermes dashboard already injects `window.__HERMES_BASE_PATH__` for this exact case (see `hermes_cli/web_server.py` and `web/src/lib/api.ts` upstream), and other built-in plugin entry points already respect it (kanban, gateway client, plugin loader). This one-line change makes the achievements bundle do the same.

## Change

```diff
   async function api(path, options) {
-    const url = "/api/plugins/hermes-achievements" + path;
+    const basePath = (window.__HERMES_BASE_PATH__ || "").replace(/\/$/, "");
+    const url = basePath + "/api/plugins/hermes-achievements" + path;
```

When no prefix is in use, `basePath` is the empty string, so the URL is unchanged for the default dashboard. Backwards compatible by construction.

## Verification

Locally under the Home Assistant Hermes add-on (dashboard mounted at `/dashboard/`):

```
$ curl -s -o /dev/null -w '%{http_code}\n' \
    http://127.0.0.1:49169/dashboard/api/plugins/hermes-achievements/achievements
200

$ curl -s -o /dev/null -w '%{http_code}\n' \
    http://127.0.0.1:49169/api/plugins/hermes-achievements/achievements
404   # expected — the reverse proxy doesn't expose /api/ outside the dashboard prefix
```

With the old code, the dashboard plugin called the second URL and surfaced the 404. With the patched bundle the page loads its full payload and the live scan progresses normally.

## Mirror

The same fix was opened upstream where the plugin is vendored: NousResearch/hermes-agent#30263. Mirroring it here so future vendoring runs from this repo don't regress the dashboard for HA Ingress / reverse-proxy users.
