### PR TITLE
Add plugin.yaml so the Hermes plugin loader can discover this plugin

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,5 @@
+name: hermes-achievements
+version: 0.4.0
+description: "Steam-style achievements for vibe coding and agentic Hermes workflows."
+author: "@PCinkusz (original), NousResearch (vendored)"
+kind: dashboard


### PR DESCRIPTION
## Problem

```
$ hermes plugins enable hermes-achievements
Plugin 'hermes-achievements' is not installed or bundled.
```

Hermes's plugin loader (`hermes_cli.plugins_cmd._read_manifest_info`) only
recognizes `plugin.yaml`/`plugin.yml` at the plugin root, and skips the
directory entirely when neither is present. The dashboard server can mount
the API routes because `web_server` scans `dashboard/manifest.json`
directly, but the CLI enable/disable path and `hermes plugins list` both
miss the plugin.

This is a real blocker for end users: the vendored copy of this plugin in
`hermes-agent/plugins/hermes-achievements/` ships without a `plugin.yaml`,
so `hermes plugins enable hermes-achievements` fails on a stock Hermes
install even though the dashboard tab itself works fine.

## Fix

Add a minimal `plugin.yaml` at the repo root with the fields the loader
actually reads: `name`, `version`, `description`, plus `author` and
`kind: dashboard`. The dashboard's existing `dashboard/manifest.json`
is untouched — it stays the source of truth for the dashboard UI, while
`plugin.yaml` lets the plugin CLI find the package.

## Verification

Before:
```
$ hermes plugins list | grep hermes-achievements
$ hermes plugins enable hermes-achievements
Plugin 'hermes-achievements' is not installed or bundled.
```

After:
```
$ hermes plugins list | grep hermes-achievements
│ hermes-achievements  │ not enabled │ 0.4.0 │ Steam-style achievements … │ bundled │
$ hermes plugins enable hermes-achievements
✓ Plugin hermes-achievements enabled. Takes effect on next session.
```

## Notes for reviewers

- The change is intentionally minimal (5 lines). `plugin.yaml` only needs
  to satisfy the loader; `dashboard/manifest.json` continues to drive the
  dashboard.
- `kind: dashboard` matches the convention other vendored dashboard plugins
  use (e.g. `observability/langfuse`).
- This also fixes the same bug for users who clone this repo into
  `~/.hermes/plugins/hermes-achievements` per the README install steps — they
  hit the same loader error today.